### PR TITLE
在package配置中加入parent，便于在自定义模板时，可以直接使用框架内置的不行，无需自行写入cfg。

### DIFF
--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/ConstVal.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/ConstVal.java
@@ -35,6 +35,7 @@ public interface ConstVal {
     String MAPPER = "Mapper";
     String XML = "Xml";
     String CONTROLLER = "Controller";
+    String PARENT = "Parent";
 
     String ENTITY_PATH = "entity_path";
     String SERVICE_PATH = "service_path";

--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/PackageConfig.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/PackageConfig.java
@@ -117,6 +117,7 @@ public class PackageConfig {
             packageInfo.put(ConstVal.SERVICE, this.joinPackage(this.getService()));
             packageInfo.put(ConstVal.SERVICE_IMPL, this.joinPackage(this.getServiceImpl()));
             packageInfo.put(ConstVal.CONTROLLER, this.joinPackage(this.getController()));
+            packageInfo.put(ConstVal.PARENT, this.getParent());
         }
         return Collections.unmodifiableMap(this.packageInfo);
     }


### PR DESCRIPTION
### 该Pull Request关联的Issue

https://github.com/baomidou/generator/issues/41

### 修改描述

在`com.baomidou.mybatisplus.generator.config.ConstVal`中加入常量`String PARENT = "Parent"`
在`com.baomidou.mybatisplus.generator.config.PackageCOnfig`的`public Map<String, String> getPackageInfo()`方法中加入`packageInfo.put(ConstVal.PARENT, this.getParent());`

### 测试用例

使用了`com.baomidoou.mybatisplus.test.generator.SqliteGeneratorTest`类的`main`方法进行了测试

### 修复效果的截屏


