### PR TITLE
自定义路径时，默认路径为空问题

### DIFF
--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/builder/PathInfoHandler.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/builder/PathInfoHandler.java
@@ -41,8 +41,15 @@ class PathInfoHandler {
         this.packageConfig = packageConfig;
         Map<OutputFile, String> pathInfo = packageConfig.getPathInfo();
         if (CollectionUtils.isNotEmpty(pathInfo)) {
+            setDefaultPathInfo(globalConfig, templateConfig);
             this.pathInfo.putAll(pathInfo);
+        }else{
+            setDefaultPathInfo(globalConfig, templateConfig);
         }
+
+    }
+
+    private void setDefaultPathInfo(GlobalConfig globalConfig, TemplateConfig templateConfig){
         // 设置默认输出路径
         putPathInfo(templateConfig.getEntity(globalConfig.isKotlin()), OutputFile.entity, ConstVal.ENTITY);
         putPathInfo(templateConfig.getMapper(), OutputFile.mapper, ConstVal.MAPPER);


### PR DESCRIPTION
### #72 #71 



### 修改描述
这样设置路径时，导致其他的文件路径为空super.packageConfigBuilder().pathInfo(Collections.singletonMap(OutputFile.mapperXml, "D://"));


### 测试用例



### 修复效果的截屏
![image](https://user-images.githubusercontent.com/3069732/122184276-a7d82300-cebe-11eb-8976-0a8426a67513.png)


