### PR TITLE
udpate entity.java.ftl 实现setEntityBooleanColumnRemoveIsPrefix策略，能真正的去…

### DIFF
--- a/mybatis-plus-generator/src/main/resources/templates/entity.java.ftl
+++ b/mybatis-plus-generator/src/main/resources/templates/entity.java.ftl
@@ -94,12 +94,8 @@ public class ${entity} implements Serializable {
     <#if field.logicDeleteField>
     @TableLogic
     </#if>
-    <#if entityBooleanColumnRemoveIsPrefix>
-    <#if (field.propertyName)?contains("is")>
+    <#if entityBooleanColumnRemoveIsPrefix && (field.propertyName)?contains("is")>
     private Boolean ${field.propertyName?replace("is","")?uncap_first};
-    <#else>
-    private ${field.propertyType} ${field.propertyName};
-    </#if>
     <#else>
     private ${field.propertyType} ${field.propertyName};
     </#if>

--- a/mybatis-plus-generator/src/main/resources/templates/entity.java.ftl
+++ b/mybatis-plus-generator/src/main/resources/templates/entity.java.ftl
@@ -94,7 +94,15 @@ public class ${entity} implements Serializable {
     <#if field.logicDeleteField>
     @TableLogic
     </#if>
+    <#if entityBooleanColumnRemoveIsPrefix>
+    <#if (field.propertyName)?contains("is")>
+    private Boolean ${field.propertyName?replace("is","")?uncap_first};
+    <#else>
     private ${field.propertyType} ${field.propertyName};
+    </#if>
+    <#else>
+    private ${field.propertyType} ${field.propertyName};
+    </#if>
 </#list>
 <#------------  END 字段循环遍历  ---------->
 


### PR DESCRIPTION
…除掉数据库中的is字段前缀

### 该Pull Request关联的Issue

#90 

### 修改描述

添加对entityBooleanColumnRemoveIsPrefix的判断，如果为true
则判断filed.propertyName是否包含is，如果包含则生成的模板为Boolean + propertyName.replace("is","");
否则按照

### 测试用例
测试一个数据库字段为is_deleted的类型为tinyint的表
生成的实体类为如下图所示

### 修复效果的截屏
![image](https://user-images.githubusercontent.com/36438675/127296175-a464d8c6-49ea-4b84-b822-8acfaa886377.png)


