### PR TITLE
修复btl模板生成Entity时"pkVal"方法无法获取主键id属性问题

### DIFF
--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/IDatabaseQuery.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/IDatabaseQuery.java
@@ -151,7 +151,7 @@ public abstract class IDatabaseQuery {
                         tableList.addAll(includeTableList);
                     }
                 }
-                // 性能优化，只处理需执行表字段 github issues/219
+                // 性能优化，只处理需执行表字段 https://github.com/baomidou/mybatis-plus/issues/219
                 tableList.forEach(this::convertTableFields);
                 return tableList;
             } catch (SQLException e) {

--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/GlobalConfig.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/GlobalConfig.java
@@ -40,8 +40,9 @@ public class GlobalConfig {
     private String outputDir = System.getProperty("os.name").toLowerCase().contains("windows") ? "D://" : "/tmp";
 
     /**
-     * 是否覆盖已有文件（默认 false）
+     * 是否覆盖已有文件（默认 false）（3.5.3版本会删除此方法）
      */
+    @Deprecated
     private boolean fileOverride;
 
     /**
@@ -80,6 +81,10 @@ public class GlobalConfig {
         return outputDir;
     }
 
+    /**
+     * 是否覆盖已有文件（3.5.3版本会删除此方法）
+     */
+    @Deprecated
     public boolean isFileOverride() {
         return fileOverride;
     }
@@ -125,8 +130,9 @@ public class GlobalConfig {
         }
 
         /**
-         * 覆盖已有文件
+         * 覆盖已有文件（3.5.3版本会删除此方法）
          */
+        @Deprecated
         public Builder fileOverride() {
             this.globalConfig.fileOverride = true;
             return this;
@@ -135,7 +141,7 @@ public class GlobalConfig {
         /**
          * 禁止打开输出目录
          */
-        public Builder disableOpenDir(){
+        public Builder disableOpenDir() {
             this.globalConfig.open = false;
             return this;
         }

--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/INameConvert.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/INameConvert.java
@@ -70,7 +70,7 @@ public interface INameConvert {
 
         @Override
         public @NotNull String propertyNameConvert(@NotNull TableField field) {
-            return processName(field.getName(), strategyConfig.entity().getNaming(), strategyConfig.getFieldPrefix(), strategyConfig.getFieldSuffix());
+            return processName(field.getName(), strategyConfig.entity().getColumnNaming(), strategyConfig.getFieldPrefix(), strategyConfig.getFieldSuffix());
         }
 
         private String processName(String name, NamingStrategy strategy, Set<String> prefix, Set<String> suffix) {

--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/InjectionConfig.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/InjectionConfig.java
@@ -45,6 +45,13 @@ public class InjectionConfig {
      */
     private Map<String, String> customFile = new HashMap<>();
 
+    /**
+     * 是否覆盖已有文件（默认 false）
+     *
+     * @since 3.5.2
+     */
+    private boolean fileOverride;
+
     @NotNull
     public void beforeOutputFile(TableInfo tableInfo, Map<String, Object> objectMap) {
         if (!customMap.isEmpty()) {
@@ -63,6 +70,10 @@ public class InjectionConfig {
     @NotNull
     public Map<String, String> getCustomFile() {
         return customFile;
+    }
+
+    public boolean isFileOverride() {
+        return fileOverride;
     }
 
     /**
@@ -106,6 +117,14 @@ public class InjectionConfig {
          */
         public Builder customFile(@NotNull Map<String, String> customFile) {
             this.injectionConfig.customFile = customFile;
+            return this;
+        }
+
+        /**
+         * 覆盖已有文件
+         */
+        public Builder fileOverride() {
+            this.injectionConfig.fileOverride = true;
             return this;
         }
 

--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/builder/ConfigBuilder.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/builder/ConfigBuilder.java
@@ -27,7 +27,7 @@ import java.util.regex.Pattern;
 /**
  * 配置汇总 传递给文件生成工具
  *
- * @author YangHu, tangguo, hubin, Juzi
+ * @author YangHu, tangguo, hubin, Juzi, lanjerry
  * @since 2016-08-30
  */
 public class ConfigBuilder {
@@ -48,7 +48,7 @@ public class ConfigBuilder {
     private final Map<OutputFile, String> pathInfo = new HashMap<>();
 
     /**
-     * 策略配置
+     * 策略配置信息
      */
     private StrategyConfig strategyConfig;
 

--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/builder/Controller.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/builder/Controller.java
@@ -67,6 +67,13 @@ public class Controller implements ITemplate {
      */
     private ConverterFileName converterFileName = (entityName -> entityName + ConstVal.CONTROLLER);
 
+    /**
+     * 是否覆盖已有文件（默认 false）
+     *
+     * @since 3.5.2
+     */
+    private boolean fileOverride;
+
     public boolean isRestStyle() {
         return restStyle;
     }
@@ -83,6 +90,10 @@ public class Controller implements ITemplate {
     @NotNull
     public ConverterFileName getConverterFileName() {
         return converterFileName;
+    }
+
+    public boolean isFileOverride() {
+        return fileOverride;
     }
 
     @Override
@@ -169,6 +180,14 @@ public class Controller implements ITemplate {
          */
         public Builder formatFileName(@NotNull String format) {
             return convertFileName((entityName) -> String.format(format, entityName));
+        }
+
+        /**
+         * 覆盖已有文件
+         */
+        public Builder fileOverride() {
+            this.controller.fileOverride = true;
+            return this;
         }
 
         @NotNull

--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/builder/Entity.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/builder/Entity.java
@@ -175,6 +175,13 @@ public class Entity implements ITemplate {
     private ConverterFileName converterFileName = (entityName -> entityName);
 
     /**
+     * 是否覆盖已有文件（默认 false）
+     *
+     * @since 3.5.2
+     */
+    private boolean fileOverride;
+
+    /**
      * <p>
      * 父类 Class 反射属性转换为公共字段
      * </p>
@@ -308,6 +315,10 @@ public class Entity implements ITemplate {
     @NotNull
     public ConverterFileName getConverterFileName() {
         return converterFileName;
+    }
+
+    public boolean isFileOverride() {
+        return fileOverride;
     }
 
     @Override
@@ -600,6 +611,14 @@ public class Entity implements ITemplate {
          */
         public Builder formatFileName(String format) {
             return convertFileName((entityName) -> String.format(format, entityName));
+        }
+
+        /**
+         * 覆盖已有文件
+         */
+        public Builder fileOverride() {
+            this.entity.fileOverride = true;
+            return this;
         }
 
         public Entity get() {

--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/builder/Mapper.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/builder/Mapper.java
@@ -80,6 +80,13 @@ public class Mapper implements ITemplate {
     private ConverterFileName converterXmlFileName = (entityName -> entityName + ConstVal.MAPPER);
 
     /**
+     * 是否覆盖已有文件（默认 false）
+     *
+     * @since 3.5.2
+     */
+    private boolean fileOverride;
+
+    /**
      * 设置缓存实现类
      *
      * @since 3.5.0
@@ -113,6 +120,10 @@ public class Mapper implements ITemplate {
 
     public Class<? extends Cache> getCache() {
         return this.cache == null ? LoggingCache.class : this.cache;
+    }
+
+    public boolean isFileOverride() {
+        return fileOverride;
     }
 
     @Override
@@ -253,6 +264,14 @@ public class Mapper implements ITemplate {
          */
         public Builder formatXmlFileName(@NotNull String format) {
             return convertXmlFileName((entityName) -> String.format(format, entityName));
+        }
+
+        /**
+         * 覆盖已有文件
+         */
+        public Builder fileOverride() {
+            this.mapper.fileOverride = true;
+            return this;
         }
 
         @NotNull

--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/builder/Service.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/builder/Service.java
@@ -71,6 +71,13 @@ public class Service implements ITemplate {
      */
     private ConverterFileName converterServiceImplFileName = (entityName -> entityName + ConstVal.SERVICE_IMPL);
 
+    /**
+     * 是否覆盖已有文件（默认 false）
+     *
+     * @since 3.5.2
+     */
+    private boolean fileOverride;
+
     @NotNull
     public ConverterFileName getConverterServiceFileName() {
         return converterServiceFileName;
@@ -79,6 +86,10 @@ public class Service implements ITemplate {
     @NotNull
     public ConverterFileName getConverterServiceImplFileName() {
         return converterServiceImplFileName;
+    }
+
+    public boolean isFileOverride() {
+        return fileOverride;
     }
 
     @Override
@@ -186,6 +197,14 @@ public class Service implements ITemplate {
          */
         public Builder formatServiceImplFileName(@NotNull String format) {
             return convertServiceImplFileName((entityName) -> String.format(format, entityName));
+        }
+
+        /**
+         * 覆盖已有文件
+         */
+        public Builder fileOverride() {
+            this.service.fileOverride = true;
+            return this;
         }
 
         @NotNull

--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/po/TableInfo.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/po/TableInfo.java
@@ -222,7 +222,7 @@ public class TableInfo {
                 this.importPackages.add(Model.class.getCanonicalName());
             }
         }
-        if (entity.isSerialVersionUID()) {
+        if (entity.isSerialVersionUID() || entity.isActiveRecord()) {
             this.importPackages.add(Serializable.class.getCanonicalName());
         }
         if (this.isConvert()) {

--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/po/TableInfo.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/po/TableInfo.java
@@ -33,30 +33,94 @@ import java.util.stream.Collectors;
 /**
  * 表信息，关联到当前字段信息
  *
- * @author YangHu
+ * @author YangHu, lanjerry
  * @since 2016/8/30
  */
 public class TableInfo {
+
+    /**
+     * 策略配置
+     */
     private final StrategyConfig strategyConfig;
+
+    /**
+     * 全局配置信息
+     */
     private final GlobalConfig globalConfig;
+
+    /**
+     * 包导入信息
+     */
     private final Set<String> importPackages = new TreeSet<>();
+
+    /**
+     * 是否转换
+     */
     private boolean convert;
+
+    /**
+     * 表名称
+     */
     private String name;
+
+    /**
+     * 表注释
+     */
     private String comment;
+
+    /**
+     * 实体名称
+     */
     private String entityName;
+
+    /**
+     * mapper名称
+     */
     private String mapperName;
+
+    /**
+     * xml名称
+     */
     private String xmlName;
+
+    /**
+     * service名称
+     */
     private String serviceName;
+
+    /**
+     * serviceImpl名称
+     */
     private String serviceImplName;
+
+    /**
+     * controller名称
+     */
     private String controllerName;
+
+    /**
+     * 表字段
+     */
     private final List<TableField> fields = new ArrayList<>();
+
+    /**
+     * 是否有主键
+     */
     private boolean havePrimaryKey;
+
     /**
      * 公共字段
      */
     private final List<TableField> commonFields = new ArrayList<>();
+
+    /**
+     * 字段名称集
+     */
     private String fieldNames;
 
+    /**
+     * 实体
+     */
     private final Entity entity;
 
     /**

--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/engine/AbstractTemplateEngine.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/engine/AbstractTemplateEngine.java
@@ -69,7 +69,7 @@ public abstract class AbstractTemplateEngine {
         String otherPath = getPathInfo(OutputFile.other);
         customFile.forEach((key, value) -> {
             String fileName = String.format((otherPath + File.separator + entityName + File.separator + "%s"), key);
-            outputFile(new File(fileName), objectMap, value);
+            outputFile(new File(fileName), objectMap, value, getConfigBuilder().getInjectionConfig().isFileOverride());
         });
     }
 
@@ -86,7 +86,7 @@ public abstract class AbstractTemplateEngine {
         if (StringUtils.isNotBlank(entityName) && StringUtils.isNotBlank(entityPath)) {
             getTemplateFilePath(template -> template.getEntity(getConfigBuilder().getGlobalConfig().isKotlin())).ifPresent((entity) -> {
                 String entityFile = String.format((entityPath + File.separator + "%s" + suffixJavaOrKt()), entityName);
-                outputFile(new File(entityFile), objectMap, entity);
+                outputFile(new File(entityFile), objectMap, entity, getConfigBuilder().getStrategyConfig().entity().isFileOverride());
             });
         }
     }
@@ -105,7 +105,7 @@ public abstract class AbstractTemplateEngine {
         if (StringUtils.isNotBlank(tableInfo.getMapperName()) && StringUtils.isNotBlank(mapperPath)) {
             getTemplateFilePath(TemplateConfig::getMapper).ifPresent(mapper -> {
                 String mapperFile = String.format((mapperPath + File.separator + tableInfo.getMapperName() + suffixJavaOrKt()), entityName);
-                outputFile(new File(mapperFile), objectMap, mapper);
+                outputFile(new File(mapperFile), objectMap, mapper, getConfigBuilder().getStrategyConfig().mapper().isFileOverride());
             });
         }
         // MpMapper.xml
@@ -113,7 +113,7 @@ public abstract class AbstractTemplateEngine {
         if (StringUtils.isNotBlank(tableInfo.getXmlName()) && StringUtils.isNotBlank(xmlPath)) {
             getTemplateFilePath(TemplateConfig::getXml).ifPresent(xml -> {
                 String xmlFile = String.format((xmlPath + File.separator + tableInfo.getXmlName() + ConstVal.XML_SUFFIX), entityName);
-                outputFile(new File(xmlFile), objectMap, xml);
+                outputFile(new File(xmlFile), objectMap, xml, getConfigBuilder().getStrategyConfig().mapper().isFileOverride());
             });
         }
     }
@@ -132,7 +132,7 @@ public abstract class AbstractTemplateEngine {
         if (StringUtils.isNotBlank(tableInfo.getServiceName()) && StringUtils.isNotBlank(servicePath)) {
             getTemplateFilePath(TemplateConfig::getService).ifPresent(service -> {
                 String serviceFile = String.format((servicePath + File.separator + tableInfo.getServiceName() + suffixJavaOrKt()), entityName);
-                outputFile(new File(serviceFile), objectMap, service);
+                outputFile(new File(serviceFile), objectMap, service, getConfigBuilder().getStrategyConfig().service().isFileOverride());
             });
         }
         // MpServiceImpl.java
@@ -140,7 +140,7 @@ public abstract class AbstractTemplateEngine {
         if (StringUtils.isNotBlank(tableInfo.getServiceImplName()) && StringUtils.isNotBlank(serviceImplPath)) {
             getTemplateFilePath(TemplateConfig::getServiceImpl).ifPresent(serviceImpl -> {
                 String implFile = String.format((serviceImplPath + File.separator + tableInfo.getServiceImplName() + suffixJavaOrKt()), entityName);
-                outputFile(new File(implFile), objectMap, serviceImpl);
+                outputFile(new File(implFile), objectMap, serviceImpl, getConfigBuilder().getStrategyConfig().service().isFileOverride());
             });
         }
     }
@@ -159,9 +159,22 @@ public abstract class AbstractTemplateEngine {
             getTemplateFilePath(TemplateConfig::getController).ifPresent(controller -> {
                 String entityName = tableInfo.getEntityName();
                 String controllerFile = String.format((controllerPath + File.separator + tableInfo.getControllerName() + suffixJavaOrKt()), entityName);
-                outputFile(new File(controllerFile), objectMap, controller);
+                outputFile(new File(controllerFile), objectMap, controller, getConfigBuilder().getStrategyConfig().controller().isFileOverride());
             });
         }
+    }
+
+    /**
+     * 输出文件（3.5.3版本会删除此方法）
+     *
+     * @param file         文件
+     * @param objectMap    渲染信息
+     * @param templatePath 模板路径
+     * @since 3.5.0
+     */
+    @Deprecated
+    protected void outputFile(@NotNull File file, @NotNull Map<String, Object> objectMap, @NotNull String templatePath) {
+        outputFile(file, objectMap, templatePath, false);
     }
 
     /**
@@ -170,10 +183,11 @@ public abstract class AbstractTemplateEngine {
      * @param file         文件
      * @param objectMap    渲染信息
      * @param templatePath 模板路径
-     * @since 3.5.0
+     * @param fileOverride 是否覆盖已有文件
+     * @since 3.5.2
      */
-    protected void outputFile(@NotNull File file, @NotNull Map<String, Object> objectMap, @NotNull String templatePath) {
-        if (isCreate(file)) {
+    protected void outputFile(@NotNull File file, @NotNull Map<String, Object> objectMap, @NotNull String templatePath, boolean fileOverride) {
+        if (isCreate(file, fileOverride)) {
             try {
                 // 全局判断【默认】
                 boolean exist = file.exists();
@@ -231,13 +245,13 @@ public abstract class AbstractTemplateEngine {
                     // 输出自定义文件
                     outputCustomFile(t.getCustomFile(), tableInfo, objectMap);
                 });
-                // Mp.java
+                // entity
                 outputEntity(tableInfo, objectMap);
                 // mapper and xml
                 outputMapper(tableInfo, objectMap);
                 // service
                 outputService(tableInfo, objectMap);
-                // MpController.java
+                // controller
                 outputController(tableInfo, objectMap);
             });
         } catch (Exception e) {
@@ -247,7 +261,7 @@ public abstract class AbstractTemplateEngine {
     }
 
     /**
-     * 输出文件
+     * 输出文件（3.5.3版本会删除此方法）
      *
      * @param objectMap    渲染数据
      * @param templatePath 模板路径
@@ -261,7 +275,7 @@ public abstract class AbstractTemplateEngine {
     }
 
     /**
-     * 将模板转化成为文件
+     * 将模板转化成为文件（3.5.3版本会删除此方法）
      *
      * @param objectMap    渲染对象 MAP 信息
      * @param templatePath 模板文件
@@ -355,7 +369,7 @@ public abstract class AbstractTemplateEngine {
     public abstract String templateFilePath(@NotNull String filePath);
 
     /**
-     * 检测文件是否存在
+     * 检测文件是否存在（3.5.3版本会删除此方法）
      *
      * @return 文件是否存在
      * @deprecated 3.5.0
@@ -366,15 +380,29 @@ public abstract class AbstractTemplateEngine {
     }
 
     /**
-     * 检查文件是否创建文件
+     * 检查文件是否创建文件（3.5.3版本会删除此方法）
      *
      * @param file 文件
      * @return 是否创建文件
      * @since 3.5.0
      */
+    @Deprecated
     protected boolean isCreate(@NotNull File file) {
         // 全局判断【默认】
         return !file.exists() || getConfigBuilder().getGlobalConfig().isFileOverride();
+    }
+
+    /**
+     * 检查文件是否创建文件
+     *
+     * @param file         文件
+     * @param fileOverride 是否覆盖已有文件
+     * @return 是否创建文件
+     * @since 3.5.2
+     */
+    protected boolean isCreate(@NotNull File file, boolean fileOverride) {
+        // 全局判断【默认】
+        return !file.exists() || fileOverride;
     }
 
     /**

--- a/mybatis-plus-generator/src/test/java/com/baomidou/mybatisplus/generator/config/StrategyConfigTest.java
+++ b/mybatis-plus-generator/src/test/java/com/baomidou/mybatisplus/generator/config/StrategyConfigTest.java
@@ -247,8 +247,10 @@ class StrategyConfigTest {
         Assertions.assertTrue(strategyConfig.entity().isChain());
         Assertions.assertTrue(strategyConfig.entity().isLombok());
         Assertions.assertTrue(strategyConfig.entity().isSerialVersionUID());
+        Assertions.assertTrue(strategyConfig.entity().isFileOverride());
         Assertions.assertTrue(strategyConfig.controller().isHyphenStyle());
         Assertions.assertTrue(strategyConfig.controller().isRestStyle());
+        Assertions.assertFalse(strategyConfig.controller().isFileOverride());
         Assertions.assertEquals("com.baomidou.mp.SuperController", strategyConfig.controllerBuilder().get().getSuperClass());
         Assertions.assertEquals("com.baomidou.mp.SuperMapper", strategyConfig.mapper().getSuperClass());
     }
@@ -257,13 +259,13 @@ class StrategyConfigTest {
     void builderTest() {
         StrategyConfig strategyConfig;
         strategyConfig = GeneratorBuilder.strategyConfigBuilder().enableCapitalMode().enableSkipView()
-            .entityBuilder().enableChainModel().enableLombok()
+            .entityBuilder().enableChainModel().enableLombok().fileOverride()
             .controllerBuilder().enableHyphenStyle().enableRestStyle().superClass("com.baomidou.mp.SuperController")
             .mapperBuilder().superClass("com.baomidou.mp.SuperMapper").build();
 
         buildAssert(strategyConfig);
         strategyConfig = GeneratorBuilder.strategyConfigBuilder().enableSkipView()
-            .entityBuilder().enableChainModel().enableLombok()
+            .entityBuilder().enableChainModel().enableLombok().fileOverride()
             .controllerBuilder().superClass("com.baomidou.mp.SuperController").enableHyphenStyle().enableRestStyle()
             .mapperBuilder().superClass("com.baomidou.mp.SuperMapper").build();
         buildAssert(strategyConfig);


### PR DESCRIPTION
### 该Pull Request关联的Issue
无，是我自己用的时候自己发现的

### 修改描述
使用btl生成Entity时，因为btl中"keyPropertyName"定义的位置问题，导致生成pkVal()方法时无法正常生成，本次修改将keyPropertyName位置提到循环上面


### 测试用例



### 修复效果的截屏
修复前：
![image](https://user-images.githubusercontent.com/24310185/146546247-b98371cd-0e08-4d8f-bdfb-63e8cae458e5.png)

修复后：
![image](https://user-images.githubusercontent.com/24310185/146546279-ff58f94f-0264-46ab-9149-879b6835a308.png)


