### PR TITLE
修复btl模板生成Entity时"pkVal"方法无法获取主键id属性问题

### DIFF
--- a/mybatis-plus-generator/src/main/resources/templates/entity.java.btl
+++ b/mybatis-plus-generator/src/main/resources/templates/entity.java.btl
@@ -49,11 +49,12 @@ public class ${entity} {
 
     private static final long serialVersionUID = 1L;
 <% } %>
+<% var keyPropertyName; %>
 <% /** -----------BEGIN 字段循环遍历----------- **/ %>
 <% for(field in table.fields){ %>
     <%
     if(field.keyFlag){
-        var keyPropertyName = field.propertyName;
+        keyPropertyName = field.propertyName;
     }
     %>
 


### PR DESCRIPTION
修复btl模板生成Entity时"pkVal"方法无法获取主键id属性问题

### 该Pull Request关联的Issue
无，自己使用时发现的


### 修改描述
keyPropertyName字段的定义位置问题，导致在循环结束后，生成pkVal方法时，无法进入if，所以每次生成的pkVal方法中均是：return null;


### 测试用例
无

### 修复效果的截屏

修改前生成的pkVal方法
![image](https://user-images.githubusercontent.com/24310185/146547379-7d4575ad-8252-45da-bbfd-bb43eae2197f.png)

修改后：
![image](https://user-images.githubusercontent.com/24310185/146547398-9ba7ad27-9725-4030-8ce0-7aa7d46b2726.png)



