### PR TITLE
修复当开启实体类常量配置时，常量名称优先采用用户自定义的属性名称

### DIFF
--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/entity/ColumnConstant.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/entity/ColumnConstant.java
@@ -1,0 +1,34 @@
+/**
+ * @Project:
+ * @Author: leegoo
+ * @Date: 2021年12月30日
+ */
+package com.baomidou.mybatisplus.generator.entity;
+
+/**
+ * ClassName: ColumnConstant
+ * @Description:实体类 生成常量 对象
+ * @author leegoo
+ * @date 2021年12月30日
+ */
+public class ColumnConstant {
+    private String name;
+    private String value;
+
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/mybatis-plus-generator/src/main/resources/templates/entity.java.vm
+++ b/mybatis-plus-generator/src/main/resources/templates/entity.java.vm
@@ -124,10 +124,15 @@ public class ${entity} {
 ## --end of #if(!${entityLombokModel})--
 
 #if(${entityColumnConstant})
-  #foreach($field in ${table.fields})
+    #if(${columnConstantList})
+        #foreach($columnConstant in ${columnConstantList})
+    public static final String ${columnConstant.name} = "${columnConstant.value}";
+        #end
+    #else
+        #foreach($field in ${table.fields})
     public static final String ${field.name.toUpperCase()} = "${field.name}";
-
-  #end
+        #end
+    #end
 #end
 #if(${activeRecord})
     @Override

--- a/mybatis-plus-generator/src/test/java/com/baomidou/mybatisplus/generator/samples/EntityConstantAutoGeneratorTest.java
+++ b/mybatis-plus-generator/src/test/java/com/baomidou/mybatisplus/generator/samples/EntityConstantAutoGeneratorTest.java
@@ -1,0 +1,75 @@
+package com.baomidou.mybatisplus.generator.samples;
+
+import com.baomidou.mybatisplus.generator.FastAutoGenerator;
+import com.baomidou.mybatisplus.generator.config.DataSourceConfig;
+import com.baomidou.mybatisplus.generator.config.INameConvert;
+import com.baomidou.mybatisplus.generator.config.po.TableField;
+import com.baomidou.mybatisplus.generator.config.po.TableInfo;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.ibatis.jdbc.ScriptRunner;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+/**
+ * <p>
+ * 快速生成
+ * </p>
+ *
+ * @author lanjerry
+ * @since 2021-09-16
+ */
+public class EntityConstantAutoGeneratorTest {
+
+    /**
+     * 执行初始化数据库脚本
+     */
+    public static void before() throws SQLException {
+        Connection conn = DATA_SOURCE_CONFIG.build().getConn();
+        InputStream inputStream = H2CodeGeneratorTest.class.getResourceAsStream("/sql/entity_constant_init.sql");
+        ScriptRunner scriptRunner = new ScriptRunner(conn);
+        scriptRunner.setAutoCommit(true);
+        scriptRunner.runScript(new InputStreamReader(inputStream));
+        conn.close();
+    }
+
+    /**
+     * 数据源配置
+     */
+    private static final DataSourceConfig.Builder DATA_SOURCE_CONFIG = new DataSourceConfig
+        .Builder("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;CASE_INSENSITIVE_IDENTIFIERS=TRUE;MODE=MYSQL", "sa", "");
+
+    /**
+     * 执行 run
+     */
+    public static void main(String[] args) throws SQLException {
+        before();
+        FastAutoGenerator.create(DATA_SOURCE_CONFIG)
+            // 全局配置
+            .globalConfig((scanner, builder) -> builder.author("leegoo").fileOverride())
+            // 包配置
+            .packageConfig((scanner, builder) -> builder.parent("com.test"))
+            // 策略配置
+            .strategyConfig(builder -> builder.addInclude("t_simple").entityBuilder().enableColumnConstant().nameConvert(new INameConvert() {
+                @Override
+                public @NotNull String entityNameConvert(@NotNull TableInfo tableInfo) {
+                    return tableInfo.getName();
+                }
+
+                @Override
+                public @NotNull String propertyNameConvert(@NotNull TableField field) {
+                    String name = field.getName();
+                    if (StringUtils.equalsIgnoreCase("a1",name)){
+                        return "appName";
+                    }else if (StringUtils.equalsIgnoreCase("normal_name",name)) {
+                        return "normalName";
+                    }
+                    return name;
+                }
+            }).fileOverride())
+            .execute();
+    }
+}

--- a/mybatis-plus-generator/src/test/resources/sql/entity_constant_init.sql
+++ b/mybatis-plus-generator/src/test/resources/sql/entity_constant_init.sql
@@ -1,0 +1,6 @@
+drop table if exists `t_simple`;
+create table `t_simple`
+(
+    a1        varchar(50),
+    normal_name        varchar(50)
+) COMMENT = '测试表';


### PR DESCRIPTION
### 该Pull Request关联的Issue

https://github.com/baomidou/generator/issues/164

### 修改描述

修复当开启实体类常量配置时，常量名称优先采用用户自定义的属性名称

### 测试用例
运行com.baomidou.mybatisplus.generator.samples.EntityConstantAutoGeneratorTest#main


### 修复效果的截屏
![SQL语句,a1字段预期将被转换](https://user-images.githubusercontent.com/15419380/147715092-c07ea395-eeac-4d80-b2af-5dd1a3778d01.png)
![自定义名称转换规则，将a1转化为APP_NAME](https://user-images.githubusercontent.com/15419380/147715109-6e22a1ba-7bd3-42de-8461-cf7c697026bc.png)

![生成实体类常量 名称为 APP_NAME ，值为A1 ](https://user-images.githubusercontent.com/15419380/147715081-49e4090e-8e3f-41dc-8a70-ef367e667f7e.png)

