### PR TITLE
fix:PostgreSqlQuery tableFieldsSql查詢字段是否為主鍵的是時候有誤

### DIFF
--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/querys/PostgreSqlQuery.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/querys/PostgreSqlQuery.java
@@ -32,7 +32,7 @@ public class PostgreSqlQuery extends AbstractDbQuery {
     @Override
     public String tableFieldsSql() {
         return "SELECT A.attname AS name,format_type (A.atttypid,A.atttypmod) AS type,col_description (A.attrelid,A.attnum) AS comment,\n" +
-            "(CASE WHEN (SELECT COUNT (*) FROM pg_constraint AS PC WHERE A.attnum = PC.conkey[1] AND PC.contype = 'p') > 0 THEN 'PRI' ELSE '' END) AS key \n" +
+            "(CASE WHEN (SELECT COUNT (*) FROM pg_constraint AS PC WHERE A.attnum = PC.conkey[1] AND PC.contype = 'p' AND A.attrelid = PC.conrelid) > 0 THEN 'PRI' ELSE '' END) AS key \n" +
             "FROM pg_class AS C,pg_attribute AS A WHERE A.attrelid='\"%s\"'::regclass AND A.attrelid= C.oid AND A.attnum> 0 AND NOT A.attisdropped ORDER  BY A.attnum";
     }
 


### PR DESCRIPTION
### 该Pull Request关联的Issue



### 修改描述
查詢pg表內字段是否為主鍵有誤 會查出多個字段是主鍵 而且多出來的字段 並不是主鍵
修改了sql
原始sql
![image](https://user-images.githubusercontent.com/58868273/150121466-5c3138cc-ba3a-456f-b9d1-715da4b761e5.png)
![image](https://user-images.githubusercontent.com/58868273/150121612-2a22e892-0501-42c8-9a23-8c28dc0dc593.png)
![image](https://user-images.githubusercontent.com/58868273/150121750-8b582459-4c19-4814-bb3f-c2ccdd122f61.png)


### 测试用例



### 修复效果的截屏
![image](https://user-images.githubusercontent.com/58868273/150121804-551c7bb1-ab22-491b-a745-0674e71bb25e.png)
![image](https://user-images.githubusercontent.com/58868273/150121935-ec0d9a94-e894-4fde-8c96-81168c52a995.png)


