### PR TITLE
增加java关键字转换机制，避免字段名对应java关键字时转换的entity出错

### DIFF
--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/po/TableField.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/po/TableField.java
@@ -27,6 +27,7 @@ import com.baomidou.mybatisplus.generator.config.rules.NamingStrategy;
 import com.baomidou.mybatisplus.generator.fill.Column;
 import com.baomidou.mybatisplus.generator.fill.Property;
 import com.baomidou.mybatisplus.generator.jdbc.DatabaseMetaDataWrapper;
+import com.baomidou.mybatisplus.generator.util.KeyWordsUtils;
 import org.apache.ibatis.type.JdbcType;
 import org.jetbrains.annotations.NotNull;
 
@@ -51,6 +52,7 @@ public class TableField {
     private IColumnType columnType;
     private String comment;
     private String fill;
+    private String capitalName;
     /**
      * 是否关键字
      *
@@ -255,7 +257,7 @@ public class TableField {
     }
 
     public String getPropertyName() {
-        return propertyName;
+        return KeyWordsUtils.filterJavaKeyWords(propertyName);
     }
 
     public IColumnType getColumnType() {

--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/util/KeyWordsUtils.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/util/KeyWordsUtils.java
@@ -1,0 +1,78 @@
+package com.baomidou.mybatisplus.generator.util;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableSet;
+
+/**
+ * @author caol64@gmail.com 2022/2/27.
+ */
+public class KeyWordsUtils {
+
+    private KeyWordsUtils() {
+    }
+
+    private static final Set<String> JAVA_KEYWORDS = unmodifiableSet(new HashSet<>(asList(
+        "abstract",
+        "assert",
+        "boolean",
+        "break",
+        "byte",
+        "case",
+        "catch",
+        "char",
+        "class",
+        "const",
+        "continue",
+        "default",
+        "double",
+        "do",
+        "else",
+        "enum",
+        "extends",
+        "false",
+        "final",
+        "finally",
+        "float",
+        "for",
+        "goto",
+        "if",
+        "implements",
+        "import",
+        "instanceof",
+        "interface",
+        "int",
+        "long",
+        "native",
+        "new",
+        "null",
+        "package",
+        "private",
+        "protected",
+        "public",
+        "return",
+        "short",
+        "static",
+        "strictfp",
+        "super",
+        "switch",
+        "synchronized",
+        "this",
+        "throw",
+        "throws",
+        "transient",
+        "true",
+        "try",
+        "void",
+        "volatile",
+        "while")));
+
+    @NotNull
+    public static String filterJavaKeyWords(@NotNull String propertyName) {
+        return JAVA_KEYWORDS.contains(propertyName) ? propertyName + "_" : propertyName;
+    }
+}

--- a/mybatis-plus-generator/src/test/java/com/baomidou/mybatisplus/generator/config/po/TableFieldTest.java
+++ b/mybatis-plus-generator/src/test/java/com/baomidou/mybatisplus/generator/config/po/TableFieldTest.java
@@ -58,6 +58,14 @@ public class TableFieldTest {
         tableField = new TableField(configBuilder, "is_delete").setColumnName("is_delete").setPropertyName("isDelete", DbColumnType.BOOLEAN);
         Assertions.assertEquals("delete", tableField.getPropertyName());
         Assertions.assertTrue(tableField.isConvert());
+
+        tableField = new TableField(configBuilder, "package").setColumnName("package").setPropertyName("package", DbColumnType.STRING);
+        Assertions.assertEquals("package_", tableField.getPropertyName());
+        Assertions.assertFalse(tableField.isConvert());
+        tableField = new TableField(configBuilder, "packages").setColumnName("packages").setPropertyName("packages", DbColumnType.STRING);
+        Assertions.assertEquals("packages", tableField.getPropertyName());
+        Assertions.assertFalse(tableField.isConvert());
+
     }
 
     @Test


### PR DESCRIPTION
### 该Pull Request关联的Issue
无


### 修改描述
当数据库内表字段的名称与java内置关键词一样时，无法转换导致生成的entity.java文件编译报错。
修改后在生成entity时如果字段名与java关键词一致，会在字段名后加上下划线_。
参考的是jooq的代码自动生成机制。

### 测试用例
TableFieldTest.convertTest()


### 修复效果的截屏
修改前：

![image](https://user-images.githubusercontent.com/6183265/155874762-7f59376c-8443-488a-8d02-034d61eeec35.png)

修改后：

![image](https://user-images.githubusercontent.com/6183265/155874883-b6acb938-4e2d-4417-88a1-6ac6cec431af.png)

