### PR TITLE
bugfix:postgreSQL查不到表注释

### DIFF
--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/querys/PostgreSqlQuery.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/querys/PostgreSqlQuery.java
@@ -30,7 +30,7 @@ public class PostgreSqlQuery extends AbstractDbQuery {
 
     @Override
     public String tablesSql() {
-        return "SELECT A.tablename, obj_description(relfilenode, 'pg_class') AS comments FROM pg_tables A, pg_class B WHERE A.schemaname='%s' AND A.tablename = B.relname";
+        return "SELECT A.tablename, obj_description(oid, 'pg_class') AS comments FROM pg_tables A, pg_class B WHERE A.schemaname='%s' AND A.tablename = B.relname";
     }
 
     @Override


### PR DESCRIPTION
### 该Pull Request关联的Issue



### 修改描述
postgreSQL 在 TRUNCATE TABLE之后，表的relfilenode 会变，导致使用 obj_description(relfilenode, 'pg_class') 无法查出表注释，应该使用obj_description(oid, 'pg_class')进行查询。


### 测试用例



### 修复效果的截屏
![image](https://user-images.githubusercontent.com/37074091/161045318-05786b71-7688-4783-8848-46bc0119e442.png)

![image](https://user-images.githubusercontent.com/37074091/161045115-5b43a8ac-4f64-480a-b068-cae8a7afbbf3.png)

![image](https://user-images.githubusercontent.com/37074091/161045161-7a5ba45c-4a1d-47e1-b904-1c8aacac5ec3.png)


