### PR TITLE
pg tableFieldsSql 主键获取有误

### DIFF
--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/querys/PostgreSqlQuery.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/querys/PostgreSqlQuery.java
@@ -35,28 +35,15 @@ public class PostgreSqlQuery extends AbstractDbQuery {
 
     @Override
     public String tableFieldsSql() {
-        return "SELECT\n" +
-            "   A.attname AS name,format_type (A.atttypid,A.atttypmod) AS type,col_description (A.attrelid,A.attnum) AS comment,\n" +
-            "\t D.column_default,\n" +
-            "   CASE WHEN length(B.attname) > 0 THEN 'PRI' ELSE '' END AS key\n" +
-            "FROM\n" +
-            "   pg_attribute A\n" +
-            "LEFT JOIN (\n" +
-            "    SELECT\n" +
-            "        pg_attribute.attname\n" +
-            "    FROM\n" +
-            "        pg_index,\n" +
-            "        pg_class,\n" +
-            "        pg_attribute\n" +
-            "    WHERE\n" +
-            "        pg_class.oid ='\"%s\"' :: regclass\n" +
-            "    AND pg_index.indrelid = pg_class.oid\n" +
-            "    AND pg_attribute.attrelid = pg_class.oid\n" +
-            "    AND pg_attribute.attnum = ANY (pg_index.indkey)\n" +
-            ") B ON A.attname = b.attname\n" +
-            "INNER JOIN pg_class C on A.attrelid = C.oid\n" +
-            "INNER JOIN information_schema.columns D on A.attname = D.column_name\n" +
-            "WHERE A.attrelid ='\"%s\"' :: regclass AND A.attnum> 0 AND NOT A.attisdropped AND D.table_name = '%s'\n" +
+        return "SELECT " +
+            "   A.attname AS name,format_type (A.atttypid,A.atttypmod) AS type,col_description (A.attrelid,A.attnum) AS comment, " +
+            "   D.column_default, " +
+            "   (CASE WHEN (SELECT COUNT (*) FROM pg_constraint AS PC WHERE A.attnum = PC.conkey[1] AND PC.contype = 'p' AND A.attrelid = PC.conrelid) > 0 THEN 'PRI' ELSE '' END) AS key " +
+            "FROM " +
+            "   pg_attribute A " +
+            "INNER JOIN pg_class C on A.attrelid = C.oid " +
+            "INNER JOIN information_schema.columns D on A.attname = D.column_name " +
+            "WHERE A.attrelid ='\"%s\"' :: regclass AND A.attnum> 0 AND NOT A.attisdropped AND D.table_name = '%s' " +
             "ORDER BY A.attnum;";
     }
 


### PR DESCRIPTION
### 修改描述
查询pg表内字段是否为主键有误 会查出多个字段是主键 而且多出来的字段 并不是主键
#### 原始sql
![image](https://user-images.githubusercontent.com/58868273/161379256-bdfc9d57-b50d-40cd-b819-5ce774a79e65.png)
#### 结果
![image](https://user-images.githubusercontent.com/58868273/161379294-0d7c53af-2c62-46ea-ac78-119abcd041ea.png)
#### 修改后的sql
![image](https://user-images.githubusercontent.com/58868273/161379386-eebd7859-7d50-4f95-a2f8-b0c997f5cff1.png)
#### 结果
![image](https://user-images.githubusercontent.com/58868273/161379410-114bd643-0da4-4987-a21f-5f822b516bc5.png)
#### pg版本
PostgreSQL 12.4 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-39), 64-bit



