### PR TITLE
支持多个自定义模板文件，分别设置文件名、模板路径、包名、是否覆盖

### DIFF
--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/ConstVal.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/ConstVal.java
@@ -35,7 +35,6 @@ public interface ConstVal {
     String MAPPER = "Mapper";
     String XML = "Xml";
     String CONTROLLER = "Controller";
-    String OTHER = "Other";
     String PARENT = "Parent";
 
     String JAVA_TMPDIR = "java.io.tmpdir";

--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/InjectionConfig.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/InjectionConfig.java
@@ -15,12 +15,12 @@
  */
 package com.baomidou.mybatisplus.generator.config;
 
+import com.baomidou.mybatisplus.generator.config.builder.CustomFile;
 import com.baomidou.mybatisplus.generator.config.po.TableInfo;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.function.BiConsumer;
+import java.util.*;
+import java.util.function.Consumer;
 
 /**
  * 注入配置
@@ -31,35 +31,25 @@ import java.util.function.BiConsumer;
 public class InjectionConfig {
 
     /**
-     * 输出文件之前消费者
-     */
-    private BiConsumer<TableInfo, Map<String, Object>> beforeOutputFileBiConsumer;
-
-    /**
      * 自定义配置 Map 对象
      */
     private Map<String, Object> customMap = new HashMap<>();
 
     /**
-     * 自定义模板文件，key为文件名称，value为模板路径
+     * 自定义模板文件
      */
-    private Map<String, String> customFile = new HashMap<>();
-
-    /**
-     * 是否覆盖已有文件（默认 false）
-     *
-     * @since 3.5.2
-     */
-    private boolean fileOverride;
+    private List<CustomFile> customFile = new ArrayList<>();
 
     @NotNull
     public void beforeOutputFile(TableInfo tableInfo, Map<String, Object> objectMap) {
         if (!customMap.isEmpty()) {
             objectMap.putAll(customMap);
         }
-        if (null != beforeOutputFileBiConsumer) {
-            beforeOutputFileBiConsumer.accept(tableInfo, objectMap);
-        }
+        Optional.ofNullable(customFile).ifPresent(list -> list.forEach(customFile -> {
+            if (null != customFile.getBeforeOutputFileBiConsumer()) {
+                customFile.getBeforeOutputFileBiConsumer().accept(tableInfo, objectMap);
+            }
+        }));
     }
 
     @NotNull
@@ -68,12 +58,8 @@ public class InjectionConfig {
     }
 
     @NotNull
-    public Map<String, String> getCustomFile() {
+    public List<CustomFile> getCustomFile() {
         return customFile;
-    }
-
-    public boolean isFileOverride() {
-        return fileOverride;
     }
 
     /**
@@ -88,43 +74,38 @@ public class InjectionConfig {
         }
 
         /**
-         * 输出文件之前消费者
-         *
-         * @param biConsumer 消费者
-         * @return this
-         */
-        public Builder beforeOutputFile(@NotNull BiConsumer<TableInfo, Map<String, Object>> biConsumer) {
-            this.injectionConfig.beforeOutputFileBiConsumer = biConsumer;
-            return this;
-        }
-
-        /**
          * 自定义配置 Map 对象
          *
          * @param customMap Map 对象
          * @return this
          */
         public Builder customMap(@NotNull Map<String, Object> customMap) {
-            this.injectionConfig.customMap = customMap;
+            this.injectionConfig.customMap.putAll(customMap);
+            return this;
+        }
+
+        /**
+         * 自定义配置 Map 对象
+         *
+         * @param key Map key
+         * @param value Map value
+         * @return this
+         */
+        public Builder putCustomMap(@NotNull String key, @NotNull Object value) {
+            this.injectionConfig.customMap.put(key, value);
             return this;
         }
 
         /**
          * 自定义配置模板文件
          *
-         * @param customFile key为文件名称，value为文件路径
+         * @param consumer 自定义模板文件配置
          * @return this
          */
-        public Builder customFile(@NotNull Map<String, String> customFile) {
-            this.injectionConfig.customFile = customFile;
-            return this;
-        }
-
-        /**
-         * 覆盖已有文件
-         */
-        public Builder fileOverride() {
-            this.injectionConfig.fileOverride = true;
+        public Builder customFile(Consumer<CustomFile.Builder> consumer) {
+            CustomFile.Builder builder = new CustomFile.Builder();
+            consumer.accept(builder);
+            this.injectionConfig.customFile.add(builder.build());
             return this;
         }
 

--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/OutputFile.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/OutputFile.java
@@ -28,5 +28,5 @@ public enum OutputFile {
     mapper,
     xml,
     controller,
-    other;
+    parent;
 }

--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/PackageConfig.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/PackageConfig.java
@@ -75,11 +75,6 @@ public class PackageConfig {
     private String controller = "controller";
 
     /**
-     * Other包名
-     */
-    private String other = "other";
-
-    /**
      * 路径配置信息
      */
     private Map<OutputFile, String> pathInfo;
@@ -130,7 +125,6 @@ public class PackageConfig {
             packageInfo.put(ConstVal.SERVICE, this.joinPackage(this.getService()));
             packageInfo.put(ConstVal.SERVICE_IMPL, this.joinPackage(this.getServiceImpl()));
             packageInfo.put(ConstVal.CONTROLLER, this.joinPackage(this.getController()));
-            packageInfo.put(ConstVal.OTHER, this.joinPackage(this.getOther()));
             packageInfo.put(ConstVal.PARENT, this.getParent());
         }
         return Collections.unmodifiableMap(this.packageInfo);
@@ -173,10 +167,6 @@ public class PackageConfig {
 
     public String getController() {
         return controller;
-    }
-
-    public String getOther() {
-        return other;
     }
 
     public Map<OutputFile, String> getPathInfo() {
@@ -288,17 +278,6 @@ public class PackageConfig {
          */
         public Builder controller(@NotNull String controller) {
             this.packageConfig.controller = controller;
-            return this;
-        }
-
-        /**
-         * 指定自定义文件包名
-         *
-         * @param other 自定义文件包名
-         * @return this
-         */
-        public Builder other(@NotNull String other) {
-            this.packageConfig.other = other;
             return this;
         }
 

--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/builder/CustomFile.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/builder/CustomFile.java
@@ -1,0 +1,131 @@
+package com.baomidou.mybatisplus.generator.config.builder;
+
+import com.baomidou.mybatisplus.generator.config.IConfigBuilder;
+import com.baomidou.mybatisplus.generator.config.po.TableInfo;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+/**
+ * 自定义模板文件配置
+ *
+ * @author xusimin
+ * @since 2022-04-06
+ */
+public class CustomFile {
+
+    /**
+     * 自定义文件名称
+     */
+    private String formatFileName;
+
+    /**
+     * 自定义模板路径
+     */
+    private String templatePath;
+
+    /**
+     * 自定义文件包名
+     */
+    private String packageName;
+
+    /**
+     * 输出文件之前消费者
+     */
+    private BiConsumer<TableInfo, Map<String, Object>> beforeOutputFileBiConsumer;
+
+    /**
+     * 是否覆盖已有文件（默认 false）
+     *
+     * @since 3.5.2
+     */
+    private boolean fileOverride;
+
+    @NotNull
+    public void beforeOutputFile(TableInfo tableInfo, Map<String, Object> objectMap) {
+        if (null != beforeOutputFileBiConsumer) {
+            beforeOutputFileBiConsumer.accept(tableInfo, objectMap);
+        }
+    }
+
+    public boolean isFileOverride() {
+        return fileOverride;
+    }
+
+    public BiConsumer<TableInfo, Map<String, Object>> getBeforeOutputFileBiConsumer() {
+        return beforeOutputFileBiConsumer;
+    }
+
+    public String getFormatFileName() {
+        return formatFileName;
+    }
+
+    public String getTemplatePath() {
+        return templatePath;
+    }
+
+    public String getPackageName() {
+        return packageName;
+    }
+
+    /**
+     * 构建者
+     */
+    public static class Builder implements IConfigBuilder<CustomFile> {
+
+        private final CustomFile customFile;
+
+        public Builder() {
+            this.customFile = new CustomFile();
+        }
+
+        /**
+         * 文件名
+         */
+        public CustomFile.Builder formatFileName(String formatFileName) {
+            this.customFile.formatFileName = formatFileName;
+            return this;
+        }
+
+        /**
+         * 模板路径
+         */
+        public CustomFile.Builder templatePath(String templatePath) {
+            this.customFile.templatePath = templatePath;
+            return this;
+        }
+
+        /**
+         * 包路径
+         */
+        public CustomFile.Builder packageName(String packageName) {
+            this.customFile.packageName = packageName;
+            return this;
+        }
+
+        /**
+         * 输出文件之前消费者
+         *
+         * @param biConsumer 消费者
+         * @return this
+         */
+        public CustomFile.Builder beforeOutputFile(@NotNull BiConsumer<TableInfo, Map<String, Object>> biConsumer) {
+            this.customFile.beforeOutputFileBiConsumer = biConsumer;
+            return this;
+        }
+
+        /**
+         * 覆盖已有文件
+         */
+        public CustomFile.Builder fileOverride() {
+            this.customFile.fileOverride = true;
+            return this;
+        }
+
+        @Override
+        public CustomFile build() {
+            return this.customFile;
+        }
+    }
+}

--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/builder/PathInfoHandler.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/builder/PathInfoHandler.java
@@ -73,7 +73,7 @@ class PathInfoHandler {
         putPathInfo(templateConfig.getService(), OutputFile.service, ConstVal.SERVICE);
         putPathInfo(templateConfig.getServiceImpl(), OutputFile.serviceImpl, ConstVal.SERVICE_IMPL);
         putPathInfo(templateConfig.getController(), OutputFile.controller, ConstVal.CONTROLLER);
-        putPathInfo(OutputFile.other, ConstVal.OTHER);
+        putPathInfo(OutputFile.parent, ConstVal.PARENT);
     }
 
     public Map<OutputFile, String> getPathInfo() {

--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/engine/AbstractTemplateEngine.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/engine/AbstractTemplateEngine.java
@@ -18,6 +18,7 @@ package com.baomidou.mybatisplus.generator.engine;
 import com.baomidou.mybatisplus.core.toolkit.StringUtils;
 import com.baomidou.mybatisplus.generator.config.*;
 import com.baomidou.mybatisplus.generator.config.builder.ConfigBuilder;
+import com.baomidou.mybatisplus.generator.config.builder.CustomFile;
 import com.baomidou.mybatisplus.generator.config.po.TableInfo;
 import com.baomidou.mybatisplus.generator.util.FileUtils;
 import com.baomidou.mybatisplus.generator.util.RuntimeUtils;
@@ -64,13 +65,12 @@ public abstract class AbstractTemplateEngine {
      * @param objectMap  渲染数据
      * @since 3.5.1
      */
-    protected void outputCustomFile(@NotNull Map<String, String> customFile, @NotNull TableInfo tableInfo, @NotNull Map<String, Object> objectMap) {
+    protected void outputCustomFile(@NotNull CustomFile customFile, @NotNull TableInfo tableInfo, @NotNull Map<String, Object> objectMap) {
         String entityName = tableInfo.getEntityName();
-        String otherPath = getPathInfo(OutputFile.other);
-        customFile.forEach((key, value) -> {
-            String fileName = String.format((otherPath + File.separator + entityName + File.separator + "%s"), key);
-            outputFile(new File(fileName), objectMap, value, getConfigBuilder().getInjectionConfig().isFileOverride());
-        });
+        String parentPath = getPathInfo(OutputFile.parent);
+        String otherPath = parentPath + File.separator + customFile.getPackageName();
+        String fileName = String.format((otherPath + File.separator + customFile.getFormatFileName()), entityName);
+        outputFile(new File(fileName), objectMap, customFile.getTemplatePath(), customFile.isFileOverride());
     }
 
     /**
@@ -243,7 +243,8 @@ public abstract class AbstractTemplateEngine {
                 Optional.ofNullable(config.getInjectionConfig()).ifPresent(t -> {
                     t.beforeOutputFile(tableInfo, objectMap);
                     // 输出自定义文件
-                    outputCustomFile(t.getCustomFile(), tableInfo, objectMap);
+                    Optional.ofNullable(t.getCustomFile()).ifPresent(list ->
+                            list.forEach(customFile -> outputCustomFile(customFile, tableInfo, objectMap)));
                 });
                 // entity
                 outputEntity(tableInfo, objectMap);


### PR DESCRIPTION
### 该Pull Request关联的Issue



### 修改描述
项目里有生成多个自定义文件的需求，分别设置文件名、模板路径、包名、是否覆盖，现有的不满足就改造了下，别人可能也有类似需求，所以提个pr。


### 测试用例



### 修复效果的截屏
```
                .injectionConfig(builder ->
                    builder
                        .putCustomMap("custom", config.getCustom())
                        .customFile(fileBuilder ->
                                fileBuilder.formatFileName("%sConverter.java")
                                    .templatePath("/templates/converter.java.ftl")
                                    .packageName("converter"))
                        .customFile(fileBuilder ->
                                fileBuilder.formatFileName("%sBO.java")
                                    .templatePath("/templates/bo.java.ftl")
                                    .packageName("model")
                                    .fileOverride())
                        .customFile(fileBuilder ->
                                fileBuilder.formatFileName("%sVO.java")
                                    .templatePath("/templates/vo.java.ftl")
                                    .packageName("model")
                                    .fileOverride())
                        .customFile(fileBuilder ->
                                fileBuilder.formatFileName("%sQO.java")
                                    .templatePath("/templates/qo.java.ftl")
                                    .packageName("model"))
                )
```

