### PR TITLE
修复日期类型指定为ONLY_DATE时，生成的Entity字段类型依然为Timestamp

### DIFF
--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/type/TypeRegistry.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/type/TypeRegistry.java
@@ -148,6 +148,8 @@ public class TypeRegistry {
         DateType dateType = globalConfig.getDateType();
         if (dateType == DateType.TIME_PACK) {
             dbColumnType = DbColumnType.LOCAL_DATE_TIME;
+        } else if (dateType == DateType.ONLY_DATE) {
+            dbColumnType = DbColumnType.DATE;
         } else {
             dbColumnType = DbColumnType.TIMESTAMP;
         }


### PR DESCRIPTION
修复当globalConfig中dateType配置为DateType.ONLY_DATE时，数据表中dateTime类型的字段依然被生成为Timestamp类型
期望应生成Date类型


### 修复效果的截屏

<img width="267" alt="image" src="https://user-images.githubusercontent.com/4480596/187139659-ba8e336c-de4c-44f9-acc7-7e5d91a73754.png">

