### PR TITLE
增加方便扩展DefaultNameConvert的配置，原本的nameConvert在Builder模式无法获取到strategyConfig

### DIFF
--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/INameConvert.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/INameConvert.java
@@ -65,6 +65,10 @@ public interface INameConvert {
 
         private StrategyConfig strategyConfig;
 
+        public DefaultNameConvert() {
+
+        }
+
         public DefaultNameConvert(StrategyConfig strategyConfig) {
             this.strategyConfig = strategyConfig;
         }

--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/INameConvert.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/INameConvert.java
@@ -50,6 +50,12 @@ public interface INameConvert {
     String propertyNameConvert(@NotNull TableField field);
 
     /**
+     * 设置策略配置
+     * @param strategyConfig
+     */
+    void setStrategyConfig(@NotNull StrategyConfig strategyConfig);
+
+    /**
      * 默认名称转换接口类
      *
      * @author nieqiurong 2020/9/20.
@@ -57,7 +63,7 @@ public interface INameConvert {
      */
     class DefaultNameConvert implements INameConvert {
 
-        private final StrategyConfig strategyConfig;
+        private StrategyConfig strategyConfig;
 
         public DefaultNameConvert(StrategyConfig strategyConfig) {
             this.strategyConfig = strategyConfig;
@@ -71,6 +77,11 @@ public interface INameConvert {
         @Override
         public @NotNull String propertyNameConvert(@NotNull TableField field) {
             return processName(field.getName(), strategyConfig.entity().getColumnNaming(), strategyConfig.getFieldPrefix(), strategyConfig.getFieldSuffix());
+        }
+
+        @Override
+        public void setStrategyConfig(@NotNull StrategyConfig strategyConfig) {
+            this.strategyConfig = strategyConfig;
         }
 
         private String processName(String name, NamingStrategy strategy, Set<String> prefix, Set<String> suffix) {

--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/builder/BaseBuilder.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/builder/BaseBuilder.java
@@ -29,6 +29,10 @@ public class BaseBuilder implements IConfigBuilder<StrategyConfig> {
 
     private final StrategyConfig strategyConfig;
 
+    public StrategyConfig getStrategyConfig() {
+        return strategyConfig;
+    }
+
     public BaseBuilder(@NotNull StrategyConfig strategyConfig) {
         this.strategyConfig = strategyConfig;
     }

--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/builder/Entity.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/builder/Entity.java
@@ -354,6 +354,9 @@ public class Entity implements ITemplate {
          */
         public Builder nameConvert(INameConvert nameConvert) {
             this.entity.nameConvert = nameConvert;
+            if (this.entity.nameConvert != null) {
+                this.entity.nameConvert.setStrategyConfig(getStrategyConfig());
+            }
             return this;
         }
 


### PR DESCRIPTION
### 该Pull Request关联的Issue

无

### 修改描述

增加方便扩展DefaultNameConvert的配置，原本的nameConvert在Builder模式无法获取到strategyConfig

### 测试用例

builder.entityBuilder()
                            .enableTableFieldAnnotation()
                            .nameConvert(new INameConvert() {
                                ...
                            })
                            .enableFileOverride();

### 修复效果的截屏


